### PR TITLE
Перехват исключений при проверке что сущность есть в identity map.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         }
     },
     "require": {
+        "php": "^7.1.3",
         "symfony/property-access": "^2.0||^3.0||^4.0",
         "symfony/doctrine-bridge": "^4.2",
         "symfony/property-info": "^4.2"

--- a/src/DataCreation.php
+++ b/src/DataCreation.php
@@ -4,7 +4,8 @@ namespace Nalogka\Codeception\Database;
 
 use Codeception\Module\Doctrine2;
 use Codeception\TestInterface;
-use Doctrine\Common\Persistence\Mapping\MappingException as PersistenceMappingException;
+use Doctrine\Persistence\Mapping\MappingException as PersistenceMappingException;
+use Doctrine\Common\Persistence\Mapping\MappingException as  AliasPersistenceMappingException;
 use Doctrine\ORM\Mapping\MappingException as OrmMappingException;
 use Doctrine\ORM\QueryBuilder;
 use Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor;
@@ -419,7 +420,7 @@ class DataCreation extends Doctrine2
                 // OrmMappingException будет выброшено в том случае,
                 // если сущность для которой мы пытаемся загрузить метаданные
                 // не является отслеживаемой доктриной.
-            } catch (PersistenceMappingException $e) {
+            } catch (PersistenceMappingException|AliasPersistenceMappingException $e) {
                 // PersistenceMappingException будет выброшено в том случае,
                 // если сущность для которой мы их пытаемся загрузить
                 // не является отслеживаемой доктриной и не найдена в


### PR DESCRIPTION
В зависимости от версии doctrine/orm может быть выкинуто как
`Doctrine\Common\Persistence\Mapping\MappingException`, так и
`Doctrine\Persistence\Mapping\MappingException`